### PR TITLE
Add widget id route parameters

### DIFF
--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -3,7 +3,7 @@
 {% block content %}
 
 {% if kind == 'route' %}
-    {{ render(path(route, params|merge(app.request.query.all))) }}
+    {{ render(path(route, params|merge(app.request.query.all)|merge({'widgetId': widget.id}))) }}
 {% else %}
     <div class="vic-render-widget-container">
         {{ cms_widget(relatedWidget) }}


### PR DESCRIPTION
Added the possibility to retrieve the widget id in the route in Victoire ~2.3.